### PR TITLE
Mihir | #0 | Upgrading openmrs-webservices.rest version to 2.6 from 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<openMRSVersion>1.9.8-SNAPSHOT</openMRSVersion>
         <openMRSRuntimeVersion>1.9.3</openMRSRuntimeVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <webservicesRestModuleVersion>2.5-SNAPSHOT</webservicesRestModuleVersion>
+        <webservicesRestModuleVersion>2.6-SNAPSHOT</webservicesRestModuleVersion>
         <openmrsAtomfeedVersion>2.0-SNAPSHOT</openmrsAtomfeedVersion>
         <atomfeed.version>1.0-SNAPSHOT</atomfeed.version>
     </properties>


### PR DESCRIPTION
Upgrading the webservices rest snapshot to version 2.6 from 2.5.
