### PR TITLE
BAH-626 | Fetch Admission & Visit Locations separately instead of Fetch All Locations

### DIFF
--- a/owa/app/components/__mocks__/openmrsApiResponse.js
+++ b/owa/app/components/__mocks__/openmrsApiResponse.js
@@ -1,0 +1,1932 @@
+export const openmrsAPIResponse = {
+    visitLocations:{
+        "results": [
+            {
+                "uuid": "c1e42932-3f10-11e4-adec-0800271c1b75",
+                "display": "Ganiyari",
+                "name": "Ganiyari",
+                "description": "Ganiyari hospital",
+                "address1": null,
+                "address2": null,
+                "cityVillage": null,
+                "stateProvince": null,
+                "country": null,
+                "postalCode": null,
+                "latitude": null,
+                "longitude": null,
+                "countyDistrict": null,
+                "address3": null,
+                "address4": null,
+                "address5": null,
+                "address6": null,
+                "tags": [
+                    {
+                        "uuid": "475d8fa3-5572-11e6-8be9-0800270d80ce",
+                        "display": "Visit Location",
+                        "name": "Visit Location",
+                        "description": "Visit Location",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    }
+                ],
+                "parentLocation": null,
+                "childLocations": [],
+                "retired": false,
+                "auditInfo": {
+                    "creator": {
+                        "uuid": "62a3b753-3f10-11e4-adec-0800271c1b75",
+                        "display": "admin",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/62a3b753-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateCreated": "2014-09-18T00:00:00.000+0800",
+                    "changedBy": null,
+                    "dateChanged": null
+                },
+                "attributes": [
+                    {
+                        "display": "IdentifierSourceName: GAN",
+                        "uuid": "c1e46f27-3f10-11e4-adec-0800271c1b75",
+                        "attributeType": {
+                            "uuid": "c1e403a0-3f10-11e4-adec-0800271c1b75",
+                            "display": "IdentifierSourceName",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationattributetype/c1e403a0-3f10-11e4-adec-0800271c1b75"
+                                }
+                            ]
+                        },
+                        "value": "GAN",
+                        "voided": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c1e42932-3f10-11e4-adec-0800271c1b75/attribute/c1e46f27-3f10-11e4-adec-0800271c1b75"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c1e42932-3f10-11e4-adec-0800271c1b75/attribute/c1e46f27-3f10-11e4-adec-0800271c1b75?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.9"
+                    }
+                ],
+                "address7": null,
+                "address8": null,
+                "address9": null,
+                "address10": null,
+                "address11": null,
+                "address12": null,
+                "address13": null,
+                "address14": null,
+                "address15": null,
+                "links": [
+                    {
+                        "rel": "self",
+                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c1e42932-3f10-11e4-adec-0800271c1b75"
+                    }
+                ],
+                "resourceVersion": "2.0"
+            },
+            {
+                "uuid": "c1e4950f-3f10-11e4-adec-0800271c1b75",
+                "display": "Subcenter 2 (SEM)",
+                "name": "Subcenter 2 (SEM)",
+                "description": "Subcenter 2 (SEM)",
+                "address1": null,
+                "address2": null,
+                "cityVillage": null,
+                "stateProvince": null,
+                "country": null,
+                "postalCode": null,
+                "latitude": null,
+                "longitude": null,
+                "countyDistrict": null,
+                "address3": null,
+                "address4": null,
+                "address5": null,
+                "address6": null,
+                "tags": [
+                    {
+                        "uuid": "475d8fa3-5572-11e6-8be9-0800270d80ce",
+                        "display": "Visit Location",
+                        "name": "Visit Location",
+                        "description": "Visit Location",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "b8bbf83e-645f-451f-8efe-a0db56f09676",
+                        "display": "Login Location",
+                        "name": "Login Location",
+                        "description": "When a user logs in and chooses a session location, they may only choose one with this tag",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    }
+                ],
+                "parentLocation": null,
+                "childLocations": [],
+                "retired": false,
+                "auditInfo": {
+                    "creator": {
+                        "uuid": "62a3b753-3f10-11e4-adec-0800271c1b75",
+                        "display": "admin",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/62a3b753-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateCreated": "2014-09-18T00:00:00.000+0800",
+                    "changedBy": null,
+                    "dateChanged": null
+                },
+                "attributes": [
+                    {
+                        "display": "IdentifierSourceName: SEM",
+                        "uuid": "c1e4e4a5-3f10-11e4-adec-0800271c1b75",
+                        "attributeType": {
+                            "uuid": "c1e403a0-3f10-11e4-adec-0800271c1b75",
+                            "display": "IdentifierSourceName",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationattributetype/c1e403a0-3f10-11e4-adec-0800271c1b75"
+                                }
+                            ]
+                        },
+                        "value": "SEM",
+                        "voided": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c1e4950f-3f10-11e4-adec-0800271c1b75/attribute/c1e4e4a5-3f10-11e4-adec-0800271c1b75"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c1e4950f-3f10-11e4-adec-0800271c1b75/attribute/c1e4e4a5-3f10-11e4-adec-0800271c1b75?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.9"
+                    }
+                ],
+                "address7": null,
+                "address8": null,
+                "address9": null,
+                "address10": null,
+                "address11": null,
+                "address12": null,
+                "address13": null,
+                "address14": null,
+                "address15": null,
+                "links": [
+                    {
+                        "rel": "self",
+                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c1e4950f-3f10-11e4-adec-0800271c1b75"
+                    }
+                ],
+                "resourceVersion": "2.0"
+            },
+            {
+                "uuid": "c1f25be5-3f10-11e4-adec-0800271c1b75",
+                "display": "Subcenter 1 (BAM)",
+                "name": "Subcenter 1 (BAM)",
+                "description": "Subcenter 1 (BAM)",
+                "address1": null,
+                "address2": null,
+                "cityVillage": null,
+                "stateProvince": null,
+                "country": null,
+                "postalCode": null,
+                "latitude": null,
+                "longitude": null,
+                "countyDistrict": null,
+                "address3": null,
+                "address4": null,
+                "address5": null,
+                "address6": null,
+                "tags": [
+                    {
+                        "uuid": "475d8fa3-5572-11e6-8be9-0800270d80ce",
+                        "display": "Visit Location",
+                        "name": "Visit Location",
+                        "description": "Visit Location",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "b8bbf83e-645f-451f-8efe-a0db56f09676",
+                        "display": "Login Location",
+                        "name": "Login Location",
+                        "description": "When a user logs in and chooses a session location, they may only choose one with this tag",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    }
+                ],
+                "parentLocation": null,
+                "childLocations": [],
+                "retired": false,
+                "auditInfo": {
+                    "creator": {
+                        "uuid": "62a3b753-3f10-11e4-adec-0800271c1b75",
+                        "display": "admin",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/62a3b753-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateCreated": "2014-09-18T00:00:00.000+0800",
+                    "changedBy": null,
+                    "dateChanged": null
+                },
+                "attributes": [
+                    {
+                        "display": "IdentifierSourceName: BAM",
+                        "uuid": "c1f2a697-3f10-11e4-adec-0800271c1b75",
+                        "attributeType": {
+                            "uuid": "c1e403a0-3f10-11e4-adec-0800271c1b75",
+                            "display": "IdentifierSourceName",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationattributetype/c1e403a0-3f10-11e4-adec-0800271c1b75"
+                                }
+                            ]
+                        },
+                        "value": "BAM",
+                        "voided": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c1f25be5-3f10-11e4-adec-0800271c1b75/attribute/c1f2a697-3f10-11e4-adec-0800271c1b75"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c1f25be5-3f10-11e4-adec-0800271c1b75/attribute/c1f2a697-3f10-11e4-adec-0800271c1b75?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.9"
+                    }
+                ],
+                "address7": null,
+                "address8": null,
+                "address9": null,
+                "address10": null,
+                "address11": null,
+                "address12": null,
+                "address13": null,
+                "address14": null,
+                "address15": null,
+                "links": [
+                    {
+                        "rel": "self",
+                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c1f25be5-3f10-11e4-adec-0800271c1b75"
+                    }
+                ],
+                "resourceVersion": "2.0"
+            },
+            {
+                "uuid": "c5854fd7-3f12-11e4-adec-0800271c1b75",
+                "display": "Registration Desk",
+                "name": "Registration Desk",
+                "description": null,
+                "address1": null,
+                "address2": null,
+                "cityVillage": null,
+                "stateProvince": "Chattisgarh",
+                "country": null,
+                "postalCode": null,
+                "latitude": null,
+                "longitude": null,
+                "countyDistrict": "Bilaspur",
+                "address3": null,
+                "address4": null,
+                "address5": null,
+                "address6": null,
+                "tags": [
+                    {
+                        "uuid": "475d8fa3-5572-11e6-8be9-0800270d80ce",
+                        "display": "Visit Location",
+                        "name": "Visit Location",
+                        "description": "Visit Location",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "b8bbf83e-645f-451f-8efe-a0db56f09676",
+                        "display": "Login Location",
+                        "name": "Login Location",
+                        "description": "When a user logs in and chooses a session location, they may only choose one with this tag",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    }
+                ],
+                "parentLocation": null,
+                "childLocations": [],
+                "retired": false,
+                "auditInfo": {
+                    "creator": {
+                        "uuid": "62a3b753-3f10-11e4-adec-0800271c1b75",
+                        "display": "admin",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/62a3b753-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateCreated": "2014-09-18T14:34:18.000+0800",
+                    "changedBy": {
+                        "uuid": "c1c21e11-3f10-11e4-adec-0800271c1b75",
+                        "display": "superman",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/c1c21e11-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateChanged": "2017-06-07T11:35:34.000+0800"
+                },
+                "attributes": [
+                    {
+                        "display": "IdentifierSourceName: SEM",
+                        "uuid": "4587f4ed-ec08-45fa-929f-13114eb23ed9",
+                        "attributeType": {
+                            "uuid": "c1e403a0-3f10-11e4-adec-0800271c1b75",
+                            "display": "IdentifierSourceName",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationattributetype/c1e403a0-3f10-11e4-adec-0800271c1b75"
+                                }
+                            ]
+                        },
+                        "value": "SEM",
+                        "voided": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c5854fd7-3f12-11e4-adec-0800271c1b75/attribute/4587f4ed-ec08-45fa-929f-13114eb23ed9"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c5854fd7-3f12-11e4-adec-0800271c1b75/attribute/4587f4ed-ec08-45fa-929f-13114eb23ed9?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.9"
+                    }
+                ],
+                "address7": null,
+                "address8": null,
+                "address9": null,
+                "address10": null,
+                "address11": null,
+                "address12": null,
+                "address13": null,
+                "address14": null,
+                "address15": null,
+                "links": [
+                    {
+                        "rel": "self",
+                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c5854fd7-3f12-11e4-adec-0800271c1b75"
+                    }
+                ],
+                "resourceVersion": "2.0"
+            },
+            {
+                "uuid": "c58e12ed-3f12-11e4-adec-0800271c1b75",
+                "display": "OPD-1",
+                "name": "OPD-1",
+                "description": null,
+                "address1": null,
+                "address2": null,
+                "cityVillage": null,
+                "stateProvince": "Chattisgarh",
+                "country": null,
+                "postalCode": null,
+                "latitude": null,
+                "longitude": null,
+                "countyDistrict": "Bilaspur",
+                "address3": null,
+                "address4": null,
+                "address5": null,
+                "address6": null,
+                "tags": [
+                    {
+                        "uuid": "475d8fa3-5572-11e6-8be9-0800270d80ce",
+                        "display": "Visit Location",
+                        "name": "Visit Location",
+                        "description": "Visit Location",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "b8bbf83e-645f-451f-8efe-a0db56f09676",
+                        "display": "Login Location",
+                        "name": "Login Location",
+                        "description": "When a user logs in and chooses a session location, they may only choose one with this tag",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "bb971de3-e0b0-11e7-aec6-02e6b64603ba",
+                        "display": "Appointment Location",
+                        "name": "Appointment Location",
+                        "description": "When a user user creates a appointment service and chooses a location, they may only choose one with this tag",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/bb971de3-e0b0-11e7-aec6-02e6b64603ba"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/bb971de3-e0b0-11e7-aec6-02e6b64603ba?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    }
+                ],
+                "parentLocation": null,
+                "childLocations": [],
+                "retired": false,
+                "auditInfo": {
+                    "creator": {
+                        "uuid": "62a3b753-3f10-11e4-adec-0800271c1b75",
+                        "display": "admin",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/62a3b753-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateCreated": "2014-09-18T14:34:18.000+0800",
+                    "changedBy": {
+                        "uuid": "c1c21e11-3f10-11e4-adec-0800271c1b75",
+                        "display": "superman",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/c1c21e11-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateChanged": "2017-06-07T16:18:05.000+0800"
+                },
+                "attributes": [
+                    {
+                        "display": "IdentifierSourceName: GAN",
+                        "uuid": "78ec2222-97c2-457d-b798-fe37c3dc7256",
+                        "attributeType": {
+                            "uuid": "c1e403a0-3f10-11e4-adec-0800271c1b75",
+                            "display": "IdentifierSourceName",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationattributetype/c1e403a0-3f10-11e4-adec-0800271c1b75"
+                                }
+                            ]
+                        },
+                        "value": "GAN",
+                        "voided": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c58e12ed-3f12-11e4-adec-0800271c1b75/attribute/78ec2222-97c2-457d-b798-fe37c3dc7256"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c58e12ed-3f12-11e4-adec-0800271c1b75/attribute/78ec2222-97c2-457d-b798-fe37c3dc7256?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.9"
+                    }
+                ],
+                "address7": null,
+                "address8": null,
+                "address9": null,
+                "address10": null,
+                "address11": null,
+                "address12": null,
+                "address13": null,
+                "address14": null,
+                "address15": null,
+                "links": [
+                    {
+                        "rel": "self",
+                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/c58e12ed-3f12-11e4-adec-0800271c1b75"
+                    }
+                ],
+                "resourceVersion": "2.0"
+            },
+            {
+                "uuid": "baf7bd38-d225-11e4-9c67-080027b662ec",
+                "display": "General Ward",
+                "name": "General Ward",
+                "description": "General Ward",
+                "address1": null,
+                "address2": null,
+                "cityVillage": null,
+                "stateProvince": "Chattisgarh",
+                "country": null,
+                "postalCode": null,
+                "latitude": null,
+                "longitude": null,
+                "countyDistrict": "Bilaspur",
+                "address3": null,
+                "address4": null,
+                "address5": null,
+                "address6": null,
+                "tags": [
+                    {
+                        "uuid": "475d8fa3-5572-11e6-8be9-0800270d80ce",
+                        "display": "Visit Location",
+                        "name": "Visit Location",
+                        "description": "Visit Location",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "b8bbf83e-645f-451f-8efe-a0db56f09676",
+                        "display": "Login Location",
+                        "name": "Login Location",
+                        "description": "When a user logs in and chooses a session location, they may only choose one with this tag",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                        "display": "Admission Location",
+                        "name": "Admission Location",
+                        "description": "General Ward Patients",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    }
+                ],
+                "parentLocation": null,
+                "childLocations": [
+                    {
+                        "uuid": "e48fb2b3-d490-11e5-b193-0800270d80ce",
+                        "display": "General Ward - Room 2",
+                        "name": "General Ward - Room 2",
+                        "description": null,
+                        "address1": null,
+                        "address2": null,
+                        "cityVillage": null,
+                        "stateProvince": null,
+                        "country": null,
+                        "postalCode": null,
+                        "latitude": null,
+                        "longitude": null,
+                        "countyDistrict": null,
+                        "address3": null,
+                        "address4": null,
+                        "address5": null,
+                        "address6": null,
+                        "tags": [],
+                        "parentLocation": {
+                            "uuid": "baf7bd38-d225-11e4-9c67-080027b662ec",
+                            "display": "General Ward",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec"
+                                }
+                            ]
+                        },
+                        "childLocations": [],
+                        "retired": false,
+                        "attributes": [],
+                        "address7": null,
+                        "address8": null,
+                        "address9": null,
+                        "address10": null,
+                        "address11": null,
+                        "address12": null,
+                        "address13": null,
+                        "address14": null,
+                        "address15": null,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/e48fb2b3-d490-11e5-b193-0800270d80ce"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/e48fb2b3-d490-11e5-b193-0800270d80ce?v=full"
+                            }
+                        ],
+                        "resourceVersion": "2.0"
+                    },
+                    {
+                        "uuid": "baf83667-d225-11e4-9c67-080027b662ec",
+                        "display": "General Ward Room 1",
+                        "name": "General Ward Room 1",
+                        "description": "1st Floor of General Ward",
+                        "address1": null,
+                        "address2": null,
+                        "cityVillage": null,
+                        "stateProvince": null,
+                        "country": null,
+                        "postalCode": null,
+                        "latitude": null,
+                        "longitude": null,
+                        "countyDistrict": null,
+                        "address3": null,
+                        "address4": null,
+                        "address5": null,
+                        "address6": null,
+                        "tags": [
+                            {
+                                "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                                "display": "Admission Location",
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                                    }
+                                ]
+                            }
+                        ],
+                        "parentLocation": {
+                            "uuid": "baf7bd38-d225-11e4-9c67-080027b662ec",
+                            "display": "General Ward",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec"
+                                }
+                            ]
+                        },
+                        "childLocations": [],
+                        "retired": false,
+                        "attributes": [],
+                        "address7": null,
+                        "address8": null,
+                        "address9": null,
+                        "address10": null,
+                        "address11": null,
+                        "address12": null,
+                        "address13": null,
+                        "address14": null,
+                        "address15": null,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf83667-d225-11e4-9c67-080027b662ec"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf83667-d225-11e4-9c67-080027b662ec?v=full"
+                            }
+                        ],
+                        "resourceVersion": "2.0"
+                    }
+                ],
+                "retired": false,
+                "auditInfo": {
+                    "creator": {
+                        "uuid": "62a3b753-3f10-11e4-adec-0800271c1b75",
+                        "display": "admin",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/62a3b753-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateCreated": "2015-03-24T18:30:22.000+0800",
+                    "changedBy": {
+                        "uuid": "c1c21e11-3f10-11e4-adec-0800271c1b75",
+                        "display": "superman",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/c1c21e11-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateChanged": "2017-06-07T16:15:36.000+0800"
+                },
+                "attributes": [
+                    {
+                        "display": "IdentifierSourceName: GAN",
+                        "uuid": "1d3a3de3-9d5a-47c5-80f3-188bf60a241d",
+                        "attributeType": {
+                            "uuid": "c1e403a0-3f10-11e4-adec-0800271c1b75",
+                            "display": "IdentifierSourceName",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationattributetype/c1e403a0-3f10-11e4-adec-0800271c1b75"
+                                }
+                            ]
+                        },
+                        "value": "GAN",
+                        "voided": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec/attribute/1d3a3de3-9d5a-47c5-80f3-188bf60a241d"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec/attribute/1d3a3de3-9d5a-47c5-80f3-188bf60a241d?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.9"
+                    }
+                ],
+                "address7": null,
+                "address8": null,
+                "address9": null,
+                "address10": null,
+                "address11": null,
+                "address12": null,
+                "address13": null,
+                "address14": null,
+                "address15": null,
+                "links": [
+                    {
+                        "rel": "self",
+                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec"
+                    }
+                ],
+                "resourceVersion": "2.0"
+            },
+            {
+                "uuid": "bb0e512e-d225-11e4-9c67-080027b662ec",
+                "display": "Labour Ward",
+                "name": "Labour Ward",
+                "description": "General Ward",
+                "address1": null,
+                "address2": null,
+                "cityVillage": null,
+                "stateProvince": "Chattisgarh",
+                "country": null,
+                "postalCode": null,
+                "latitude": null,
+                "longitude": null,
+                "countyDistrict": "Bilaspur",
+                "address3": null,
+                "address4": null,
+                "address5": null,
+                "address6": null,
+                "tags": [
+                    {
+                        "uuid": "475d8fa3-5572-11e6-8be9-0800270d80ce",
+                        "display": "Visit Location",
+                        "name": "Visit Location",
+                        "description": "Visit Location",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "b8bbf83e-645f-451f-8efe-a0db56f09676",
+                        "display": "Login Location",
+                        "name": "Login Location",
+                        "description": "When a user logs in and chooses a session location, they may only choose one with this tag",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                        "display": "Admission Location",
+                        "name": "Admission Location",
+                        "description": "General Ward Patients",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    }
+                ],
+                "parentLocation": null,
+                "childLocations": [
+                    {
+                        "uuid": "bb0eb071-d225-11e4-9c67-080027b662ec",
+                        "display": "Labour Ward - 1",
+                        "name": "Labour Ward - 1",
+                        "description": "1st Floor of General Ward",
+                        "address1": null,
+                        "address2": null,
+                        "cityVillage": null,
+                        "stateProvince": null,
+                        "country": null,
+                        "postalCode": null,
+                        "latitude": null,
+                        "longitude": null,
+                        "countyDistrict": null,
+                        "address3": null,
+                        "address4": null,
+                        "address5": null,
+                        "address6": null,
+                        "tags": [
+                            {
+                                "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                                "display": "Admission Location",
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                                    }
+                                ]
+                            }
+                        ],
+                        "parentLocation": {
+                            "uuid": "bb0e512e-d225-11e4-9c67-080027b662ec",
+                            "display": "Labour Ward",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0e512e-d225-11e4-9c67-080027b662ec"
+                                }
+                            ]
+                        },
+                        "childLocations": [],
+                        "retired": false,
+                        "attributes": [],
+                        "address7": null,
+                        "address8": null,
+                        "address9": null,
+                        "address10": null,
+                        "address11": null,
+                        "address12": null,
+                        "address13": null,
+                        "address14": null,
+                        "address15": null,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0eb071-d225-11e4-9c67-080027b662ec"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0eb071-d225-11e4-9c67-080027b662ec?v=full"
+                            }
+                        ],
+                        "resourceVersion": "2.0"
+                    }
+                ],
+                "retired": false,
+                "auditInfo": {
+                    "creator": {
+                        "uuid": "62a3b753-3f10-11e4-adec-0800271c1b75",
+                        "display": "admin",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/62a3b753-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateCreated": "2015-03-24T18:30:22.000+0800",
+                    "changedBy": {
+                        "uuid": "c1c21e11-3f10-11e4-adec-0800271c1b75",
+                        "display": "superman",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/c1c21e11-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateChanged": "2017-06-07T16:17:28.000+0800"
+                },
+                "attributes": [
+                    {
+                        "display": "IdentifierSourceName: GAN",
+                        "uuid": "20432cfe-bdb3-415b-b827-18c9f4d3835e",
+                        "attributeType": {
+                            "uuid": "c1e403a0-3f10-11e4-adec-0800271c1b75",
+                            "display": "IdentifierSourceName",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationattributetype/c1e403a0-3f10-11e4-adec-0800271c1b75"
+                                }
+                            ]
+                        },
+                        "value": "GAN",
+                        "voided": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0e512e-d225-11e4-9c67-080027b662ec/attribute/20432cfe-bdb3-415b-b827-18c9f4d3835e"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0e512e-d225-11e4-9c67-080027b662ec/attribute/20432cfe-bdb3-415b-b827-18c9f4d3835e?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.9"
+                    }
+                ],
+                "address7": null,
+                "address8": null,
+                "address9": null,
+                "address10": null,
+                "address11": null,
+                "address12": null,
+                "address13": null,
+                "address14": null,
+                "address15": null,
+                "links": [
+                    {
+                        "rel": "self",
+                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0e512e-d225-11e4-9c67-080027b662ec"
+                    }
+                ],
+                "resourceVersion": "2.0"
+            }
+        ]
+    },
+    admissionLocations:{
+        "results": [
+            {
+                "uuid": "baf7bd38-d225-11e4-9c67-080027b662ec",
+                "display": "General Ward",
+                "name": "General Ward",
+                "description": "General Ward",
+                "address1": null,
+                "address2": null,
+                "cityVillage": null,
+                "stateProvince": "Chattisgarh",
+                "country": null,
+                "postalCode": null,
+                "latitude": null,
+                "longitude": null,
+                "countyDistrict": "Bilaspur",
+                "address3": null,
+                "address4": null,
+                "address5": null,
+                "address6": null,
+                "tags": [
+                    {
+                        "uuid": "475d8fa3-5572-11e6-8be9-0800270d80ce",
+                        "display": "Visit Location",
+                        "name": "Visit Location",
+                        "description": "Visit Location",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "b8bbf83e-645f-451f-8efe-a0db56f09676",
+                        "display": "Login Location",
+                        "name": "Login Location",
+                        "description": "When a user logs in and chooses a session location, they may only choose one with this tag",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                        "display": "Admission Location",
+                        "name": "Admission Location",
+                        "description": "General Ward Patients",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    }
+                ],
+                "parentLocation": null,
+                "childLocations": [
+                    {
+                        "uuid": "e48fb2b3-d490-11e5-b193-0800270d80ce",
+                        "display": "General Ward - Room 2",
+                        "name": "General Ward - Room 2",
+                        "description": null,
+                        "address1": null,
+                        "address2": null,
+                        "cityVillage": null,
+                        "stateProvince": null,
+                        "country": null,
+                        "postalCode": null,
+                        "latitude": null,
+                        "longitude": null,
+                        "countyDistrict": null,
+                        "address3": null,
+                        "address4": null,
+                        "address5": null,
+                        "address6": null,
+                        "tags": [],
+                        "parentLocation": {
+                            "uuid": "baf7bd38-d225-11e4-9c67-080027b662ec",
+                            "display": "General Ward",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec"
+                                }
+                            ]
+                        },
+                        "childLocations": [],
+                        "retired": false,
+                        "attributes": [],
+                        "address7": null,
+                        "address8": null,
+                        "address9": null,
+                        "address10": null,
+                        "address11": null,
+                        "address12": null,
+                        "address13": null,
+                        "address14": null,
+                        "address15": null,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/e48fb2b3-d490-11e5-b193-0800270d80ce"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/e48fb2b3-d490-11e5-b193-0800270d80ce?v=full"
+                            }
+                        ],
+                        "resourceVersion": "2.0"
+                    },
+                    {
+                        "uuid": "baf83667-d225-11e4-9c67-080027b662ec",
+                        "display": "General Ward Room 1",
+                        "name": "General Ward Room 1",
+                        "description": "1st Floor of General Ward",
+                        "address1": null,
+                        "address2": null,
+                        "cityVillage": null,
+                        "stateProvince": null,
+                        "country": null,
+                        "postalCode": null,
+                        "latitude": null,
+                        "longitude": null,
+                        "countyDistrict": null,
+                        "address3": null,
+                        "address4": null,
+                        "address5": null,
+                        "address6": null,
+                        "tags": [
+                            {
+                                "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                                "display": "Admission Location",
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                                    }
+                                ]
+                            }
+                        ],
+                        "parentLocation": {
+                            "uuid": "baf7bd38-d225-11e4-9c67-080027b662ec",
+                            "display": "General Ward",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec"
+                                }
+                            ]
+                        },
+                        "childLocations": [],
+                        "retired": false,
+                        "attributes": [],
+                        "address7": null,
+                        "address8": null,
+                        "address9": null,
+                        "address10": null,
+                        "address11": null,
+                        "address12": null,
+                        "address13": null,
+                        "address14": null,
+                        "address15": null,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf83667-d225-11e4-9c67-080027b662ec"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf83667-d225-11e4-9c67-080027b662ec?v=full"
+                            }
+                        ],
+                        "resourceVersion": "2.0"
+                    }
+                ],
+                "retired": false,
+                "auditInfo": {
+                    "creator": {
+                        "uuid": "62a3b753-3f10-11e4-adec-0800271c1b75",
+                        "display": "admin",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/62a3b753-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateCreated": "2015-03-24T18:30:22.000+0800",
+                    "changedBy": {
+                        "uuid": "c1c21e11-3f10-11e4-adec-0800271c1b75",
+                        "display": "superman",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/c1c21e11-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateChanged": "2017-06-07T16:15:36.000+0800"
+                },
+                "attributes": [
+                    {
+                        "display": "IdentifierSourceName: GAN",
+                        "uuid": "1d3a3de3-9d5a-47c5-80f3-188bf60a241d",
+                        "attributeType": {
+                            "uuid": "c1e403a0-3f10-11e4-adec-0800271c1b75",
+                            "display": "IdentifierSourceName",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationattributetype/c1e403a0-3f10-11e4-adec-0800271c1b75"
+                                }
+                            ]
+                        },
+                        "value": "GAN",
+                        "voided": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec/attribute/1d3a3de3-9d5a-47c5-80f3-188bf60a241d"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec/attribute/1d3a3de3-9d5a-47c5-80f3-188bf60a241d?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.9"
+                    }
+                ],
+                "address7": null,
+                "address8": null,
+                "address9": null,
+                "address10": null,
+                "address11": null,
+                "address12": null,
+                "address13": null,
+                "address14": null,
+                "address15": null,
+                "links": [
+                    {
+                        "rel": "self",
+                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec"
+                    }
+                ],
+                "resourceVersion": "2.0"
+            },
+            {
+                "uuid": "baf83667-d225-11e4-9c67-080027b662ec",
+                "display": "General Ward Room 1",
+                "name": "General Ward Room 1",
+                "description": "1st Floor of General Ward",
+                "address1": null,
+                "address2": null,
+                "cityVillage": null,
+                "stateProvince": null,
+                "country": null,
+                "postalCode": null,
+                "latitude": null,
+                "longitude": null,
+                "countyDistrict": null,
+                "address3": null,
+                "address4": null,
+                "address5": null,
+                "address6": null,
+                "tags": [
+                    {
+                        "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                        "display": "Admission Location",
+                        "name": "Admission Location",
+                        "description": "General Ward Patients",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    }
+                ],
+                "parentLocation": {
+                    "uuid": "baf7bd38-d225-11e4-9c67-080027b662ec",
+                    "display": "General Ward",
+                    "name": "General Ward",
+                    "description": "General Ward",
+                    "address1": null,
+                    "address2": null,
+                    "cityVillage": null,
+                    "stateProvince": "Chattisgarh",
+                    "country": null,
+                    "postalCode": null,
+                    "latitude": null,
+                    "longitude": null,
+                    "countyDistrict": "Bilaspur",
+                    "address3": null,
+                    "address4": null,
+                    "address5": null,
+                    "address6": null,
+                    "tags": [
+                        {
+                            "uuid": "475d8fa3-5572-11e6-8be9-0800270d80ce",
+                            "display": "Visit Location",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce"
+                                }
+                            ]
+                        },
+                        {
+                            "uuid": "b8bbf83e-645f-451f-8efe-a0db56f09676",
+                            "display": "Login Location",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676"
+                                }
+                            ]
+                        },
+                        {
+                            "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                            "display": "Admission Location",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                                }
+                            ]
+                        }
+                    ],
+                    "parentLocation": null,
+                    "childLocations": [
+                        {
+                            "uuid": "e48fb2b3-d490-11e5-b193-0800270d80ce",
+                            "display": "General Ward - Room 2",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/e48fb2b3-d490-11e5-b193-0800270d80ce"
+                                }
+                            ]
+                        },
+                        {
+                            "uuid": "baf83667-d225-11e4-9c67-080027b662ec",
+                            "display": "General Ward Room 1",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf83667-d225-11e4-9c67-080027b662ec"
+                                }
+                            ]
+                        }
+                    ],
+                    "retired": false,
+                    "attributes": [
+                        {
+                            "uuid": "1d3a3de3-9d5a-47c5-80f3-188bf60a241d",
+                            "display": "IdentifierSourceName: GAN",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec/attribute/1d3a3de3-9d5a-47c5-80f3-188bf60a241d"
+                                }
+                            ]
+                        }
+                    ],
+                    "address7": null,
+                    "address8": null,
+                    "address9": null,
+                    "address10": null,
+                    "address11": null,
+                    "address12": null,
+                    "address13": null,
+                    "address14": null,
+                    "address15": null,
+                    "links": [
+                        {
+                            "rel": "self",
+                            "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec"
+                        },
+                        {
+                            "rel": "full",
+                            "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec?v=full"
+                        }
+                    ],
+                    "resourceVersion": "2.0"
+                },
+                "childLocations": [],
+                "retired": false,
+                "auditInfo": {
+                    "creator": {
+                        "uuid": "62a3b753-3f10-11e4-adec-0800271c1b75",
+                        "display": "admin",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/62a3b753-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateCreated": "2015-03-24T18:30:22.000+0800",
+                    "changedBy": null,
+                    "dateChanged": null
+                },
+                "attributes": [],
+                "address7": null,
+                "address8": null,
+                "address9": null,
+                "address10": null,
+                "address11": null,
+                "address12": null,
+                "address13": null,
+                "address14": null,
+                "address15": null,
+                "links": [
+                    {
+                        "rel": "self",
+                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/baf83667-d225-11e4-9c67-080027b662ec"
+                    }
+                ],
+                "resourceVersion": "2.0"
+            },
+            {
+                "uuid": "bb0e512e-d225-11e4-9c67-080027b662ec",
+                "display": "Labour Ward",
+                "name": "Labour Ward",
+                "description": "General Ward",
+                "address1": null,
+                "address2": null,
+                "cityVillage": null,
+                "stateProvince": "Chattisgarh",
+                "country": null,
+                "postalCode": null,
+                "latitude": null,
+                "longitude": null,
+                "countyDistrict": "Bilaspur",
+                "address3": null,
+                "address4": null,
+                "address5": null,
+                "address6": null,
+                "tags": [
+                    {
+                        "uuid": "475d8fa3-5572-11e6-8be9-0800270d80ce",
+                        "display": "Visit Location",
+                        "name": "Visit Location",
+                        "description": "Visit Location",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "b8bbf83e-645f-451f-8efe-a0db56f09676",
+                        "display": "Login Location",
+                        "name": "Login Location",
+                        "description": "When a user logs in and chooses a session location, they may only choose one with this tag",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    },
+                    {
+                        "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                        "display": "Admission Location",
+                        "name": "Admission Location",
+                        "description": "General Ward Patients",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    }
+                ],
+                "parentLocation": null,
+                "childLocations": [
+                    {
+                        "uuid": "bb0eb071-d225-11e4-9c67-080027b662ec",
+                        "display": "Labour Ward - 1",
+                        "name": "Labour Ward - 1",
+                        "description": "1st Floor of General Ward",
+                        "address1": null,
+                        "address2": null,
+                        "cityVillage": null,
+                        "stateProvince": null,
+                        "country": null,
+                        "postalCode": null,
+                        "latitude": null,
+                        "longitude": null,
+                        "countyDistrict": null,
+                        "address3": null,
+                        "address4": null,
+                        "address5": null,
+                        "address6": null,
+                        "tags": [
+                            {
+                                "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                                "display": "Admission Location",
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                                    }
+                                ]
+                            }
+                        ],
+                        "parentLocation": {
+                            "uuid": "bb0e512e-d225-11e4-9c67-080027b662ec",
+                            "display": "Labour Ward",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0e512e-d225-11e4-9c67-080027b662ec"
+                                }
+                            ]
+                        },
+                        "childLocations": [],
+                        "retired": false,
+                        "attributes": [],
+                        "address7": null,
+                        "address8": null,
+                        "address9": null,
+                        "address10": null,
+                        "address11": null,
+                        "address12": null,
+                        "address13": null,
+                        "address14": null,
+                        "address15": null,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0eb071-d225-11e4-9c67-080027b662ec"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0eb071-d225-11e4-9c67-080027b662ec?v=full"
+                            }
+                        ],
+                        "resourceVersion": "2.0"
+                    }
+                ],
+                "retired": false,
+                "auditInfo": {
+                    "creator": {
+                        "uuid": "62a3b753-3f10-11e4-adec-0800271c1b75",
+                        "display": "admin",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/62a3b753-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateCreated": "2015-03-24T18:30:22.000+0800",
+                    "changedBy": {
+                        "uuid": "c1c21e11-3f10-11e4-adec-0800271c1b75",
+                        "display": "superman",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/c1c21e11-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateChanged": "2017-06-07T16:17:28.000+0800"
+                },
+                "attributes": [
+                    {
+                        "display": "IdentifierSourceName: GAN",
+                        "uuid": "20432cfe-bdb3-415b-b827-18c9f4d3835e",
+                        "attributeType": {
+                            "uuid": "c1e403a0-3f10-11e4-adec-0800271c1b75",
+                            "display": "IdentifierSourceName",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationattributetype/c1e403a0-3f10-11e4-adec-0800271c1b75"
+                                }
+                            ]
+                        },
+                        "value": "GAN",
+                        "voided": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0e512e-d225-11e4-9c67-080027b662ec/attribute/20432cfe-bdb3-415b-b827-18c9f4d3835e"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0e512e-d225-11e4-9c67-080027b662ec/attribute/20432cfe-bdb3-415b-b827-18c9f4d3835e?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.9"
+                    }
+                ],
+                "address7": null,
+                "address8": null,
+                "address9": null,
+                "address10": null,
+                "address11": null,
+                "address12": null,
+                "address13": null,
+                "address14": null,
+                "address15": null,
+                "links": [
+                    {
+                        "rel": "self",
+                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0e512e-d225-11e4-9c67-080027b662ec"
+                    }
+                ],
+                "resourceVersion": "2.0"
+            },
+            {
+                "uuid": "bb0eb071-d225-11e4-9c67-080027b662ec",
+                "display": "Labour Ward - 1",
+                "name": "Labour Ward - 1",
+                "description": "1st Floor of General Ward",
+                "address1": null,
+                "address2": null,
+                "cityVillage": null,
+                "stateProvince": null,
+                "country": null,
+                "postalCode": null,
+                "latitude": null,
+                "longitude": null,
+                "countyDistrict": null,
+                "address3": null,
+                "address4": null,
+                "address5": null,
+                "address6": null,
+                "tags": [
+                    {
+                        "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                        "display": "Admission Location",
+                        "name": "Admission Location",
+                        "description": "General Ward Patients",
+                        "retired": false,
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                            },
+                            {
+                                "rel": "full",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec?v=full"
+                            }
+                        ],
+                        "resourceVersion": "1.8"
+                    }
+                ],
+                "parentLocation": {
+                    "uuid": "bb0e512e-d225-11e4-9c67-080027b662ec",
+                    "display": "Labour Ward",
+                    "name": "Labour Ward",
+                    "description": "General Ward",
+                    "address1": null,
+                    "address2": null,
+                    "cityVillage": null,
+                    "stateProvince": "Chattisgarh",
+                    "country": null,
+                    "postalCode": null,
+                    "latitude": null,
+                    "longitude": null,
+                    "countyDistrict": "Bilaspur",
+                    "address3": null,
+                    "address4": null,
+                    "address5": null,
+                    "address6": null,
+                    "tags": [
+                        {
+                            "uuid": "475d8fa3-5572-11e6-8be9-0800270d80ce",
+                            "display": "Visit Location",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/475d8fa3-5572-11e6-8be9-0800270d80ce"
+                                }
+                            ]
+                        },
+                        {
+                            "uuid": "b8bbf83e-645f-451f-8efe-a0db56f09676",
+                            "display": "Login Location",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/b8bbf83e-645f-451f-8efe-a0db56f09676"
+                                }
+                            ]
+                        },
+                        {
+                            "uuid": "a675e840-d225-11e4-9c67-080027b662ec",
+                            "display": "Admission Location",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/locationtag/a675e840-d225-11e4-9c67-080027b662ec"
+                                }
+                            ]
+                        }
+                    ],
+                    "parentLocation": null,
+                    "childLocations": [
+                        {
+                            "uuid": "bb0eb071-d225-11e4-9c67-080027b662ec",
+                            "display": "Labour Ward - 1",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0eb071-d225-11e4-9c67-080027b662ec"
+                                }
+                            ]
+                        }
+                    ],
+                    "retired": false,
+                    "attributes": [
+                        {
+                            "uuid": "20432cfe-bdb3-415b-b827-18c9f4d3835e",
+                            "display": "IdentifierSourceName: GAN",
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0e512e-d225-11e4-9c67-080027b662ec/attribute/20432cfe-bdb3-415b-b827-18c9f4d3835e"
+                                }
+                            ]
+                        }
+                    ],
+                    "address7": null,
+                    "address8": null,
+                    "address9": null,
+                    "address10": null,
+                    "address11": null,
+                    "address12": null,
+                    "address13": null,
+                    "address14": null,
+                    "address15": null,
+                    "links": [
+                        {
+                            "rel": "self",
+                            "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0e512e-d225-11e4-9c67-080027b662ec"
+                        },
+                        {
+                            "rel": "full",
+                            "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0e512e-d225-11e4-9c67-080027b662ec?v=full"
+                        }
+                    ],
+                    "resourceVersion": "2.0"
+                },
+                "childLocations": [],
+                "retired": false,
+                "auditInfo": {
+                    "creator": {
+                        "uuid": "62a3b753-3f10-11e4-adec-0800271c1b75",
+                        "display": "admin",
+                        "links": [
+                            {
+                                "rel": "self",
+                                "uri": "http://localhost:8050/openmrs/ws/rest/v1/user/62a3b753-3f10-11e4-adec-0800271c1b75"
+                            }
+                        ]
+                    },
+                    "dateCreated": "2015-03-24T18:30:22.000+0800",
+                    "changedBy": null,
+                    "dateChanged": null
+                },
+                "attributes": [],
+                "address7": null,
+                "address8": null,
+                "address9": null,
+                "address10": null,
+                "address11": null,
+                "address12": null,
+                "address13": null,
+                "address14": null,
+                "address15": null,
+                "links": [
+                    {
+                        "rel": "self",
+                        "uri": "http://localhost:8050/openmrs/ws/rest/v1/location/bb0eb071-d225-11e4-9c67-080027b662ec"
+                    }
+                ],
+                "resourceVersion": "2.0"
+            }
+        ]
+    }
+}

--- a/owa/app/components/__tests__/admissionLocation/admissionLocationWrapper-test.js
+++ b/owa/app/components/__tests__/admissionLocation/admissionLocationWrapper-test.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import {shallow} from "enzyme";
+import AdmissionLocationWrapper from "components/admissionLocation/admissionLocationWrapper.js";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios/index";
+import {IntlProvider} from "react-intl";
+import messages from 'i18n/messages';
+import {openmrsAPIResponse} from "components/__mocks__/openmrsApiResponse";
+
+require('components/__mocks__/location-mock');
+
+const intlProvider = new IntlProvider({locale: 'en', messages: messages['en']}, {});
+const {intl} = intlProvider.getChildContext();
+const testData = {
+    props: {
+        match: {
+            isExact: true,
+            params: {},
+            path: '/owa/bedmanagement/admissionLocations.html',
+            url: '/owa/bedmanagement/admissionLocations.html'
+        }
+    },
+    context: {
+        intl: intl
+    },
+    sleep: (milisec) => {
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                return resolve(true);
+            }, milisec);
+        });
+    }
+};
+
+
+describe('AdmissionLocationWrapper', () => {
+    beforeAll(() => {
+        const mock = new MockAdapter(axios);
+        mock.onGet('https://192.168.33.10/openmrs/ws/rest/v1/location', {
+                params: {
+                    tags: 'Visit Location',
+                    v: 'full'
+                }
+            }
+        ).reply(200, openmrsAPIResponse.visitLocations);
+
+        mock.onGet('https://192.168.33.10/openmrs/ws/rest/v1/location', {
+                params: {
+                    tags: 'Admission Location',
+                    v: 'full'
+                }
+            }
+        ).reply(200, openmrsAPIResponse.admissionLocations);
+
+        mock.onGet('https://192.168.33.10/openmrs/ws/rest/v1/bedtype').reply(200, {results: []});
+
+    });
+
+    it('should fetch Admission and Visit locations on load.', async () => {
+        const expectedVisitLocations = {
+            "c1e42932-3f10-11e4-adec-0800271c1b75": {
+                "uuid": "c1e42932-3f10-11e4-adec-0800271c1b75",
+                "name": "Ganiyari",
+                "description": "Ganiyari hospital"
+            },
+            "baf7bd38-d225-11e4-9c67-080027b662ec": {
+                "uuid": "baf7bd38-d225-11e4-9c67-080027b662ec",
+                "name": "General Ward",
+                "description": "General Ward"
+            },
+            "bb0e512e-d225-11e4-9c67-080027b662ec": {
+                "uuid": "bb0e512e-d225-11e4-9c67-080027b662ec",
+                "name": "Labour Ward",
+                "description": "General Ward"
+            },
+            "c58e12ed-3f12-11e4-adec-0800271c1b75": {
+                "uuid": "c58e12ed-3f12-11e4-adec-0800271c1b75",
+                "name": "OPD-1",
+                "description": null
+            },
+            "c5854fd7-3f12-11e4-adec-0800271c1b75": {
+                "uuid": "c5854fd7-3f12-11e4-adec-0800271c1b75",
+                "name": "Registration Desk",
+                "description": null
+            },
+            "c1f25be5-3f10-11e4-adec-0800271c1b75": {
+                "uuid": "c1f25be5-3f10-11e4-adec-0800271c1b75",
+                "name": "Subcenter 1 (BAM)",
+                "description": "Subcenter 1 (BAM)"
+            },
+            "c1e4950f-3f10-11e4-adec-0800271c1b75": {
+                "uuid": "c1e4950f-3f10-11e4-adec-0800271c1b75",
+                "name": "Subcenter 2 (SEM)",
+                "description": "Subcenter 2 (SEM)"
+            }
+        };
+        const expectedAdmissionLocations = {
+            "baf7bd38-d225-11e4-9c67-080027b662ec": {
+                "uuid": "baf7bd38-d225-11e4-9c67-080027b662ec",
+                "name": "General Ward",
+                "description": "General Ward",
+                "parentAdmissionLocationUuid": null,
+                "isOpen": false,
+                "isHigherLevel": true
+            },
+            "baf83667-d225-11e4-9c67-080027b662ec": {
+                "uuid": "baf83667-d225-11e4-9c67-080027b662ec",
+                "name": "General Ward Room 1",
+                "description": "1st Floor of General Ward",
+                "parentAdmissionLocationUuid": "baf7bd38-d225-11e4-9c67-080027b662ec",
+                "isOpen": false,
+                "isHigherLevel": false
+            },
+            "bb0e512e-d225-11e4-9c67-080027b662ec": {
+                "uuid": "bb0e512e-d225-11e4-9c67-080027b662ec",
+                "name": "Labour Ward",
+                "description": "General Ward",
+                "parentAdmissionLocationUuid": null,
+                "isOpen": false,
+                "isHigherLevel": true
+            },
+            "bb0eb071-d225-11e4-9c67-080027b662ec": {
+                "uuid": "bb0eb071-d225-11e4-9c67-080027b662ec",
+                "name": "Labour Ward - 1",
+                "description": "1st Floor of General Ward",
+                "parentAdmissionLocationUuid": "bb0e512e-d225-11e4-9c67-080027b662ec",
+                "isOpen": false,
+                "isHigherLevel": false
+            }
+        };
+
+        let admissionLocationWrapper = shallow(<AdmissionLocationWrapper
+                match={{path: "openmrs/owa/bedmanagement/admissionLocations.html"}}/>,
+            {context: testData.context});
+
+        const admissionLocationFunctions = admissionLocationWrapper.instance().admissionLocationFunctions;
+
+        expect(admissionLocationFunctions.getAdmissionLocations()).toEqual({});
+        expect(admissionLocationFunctions.getVisitLocations()).toEqual({});
+        await testData.sleep(100);
+
+        expect(admissionLocationFunctions.getAdmissionLocations()).toEqual(expectedAdmissionLocations);
+        expect(admissionLocationFunctions.getVisitLocations()).toEqual(expectedVisitLocations);
+    })
+});


### PR DESCRIPTION
This pull request is to fix the issue [BAH-626](https://bahmni.atlassian.net/browse/BAH-626).

Instead of fetching all the locations and then filter them based on `Admission Location/Visit Location`, now there will be two different calls to openmrs API. 

```
/openmrs/ws/rest/v1/location?tags=Admission+Location&v=full
/openmrs/ws/rest/v1/location?tags=Visit+Location&v=full
```