### PR TITLE
Fix swagger error by changing webservices version to implement requir…

### DIFF
--- a/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/AdmissionLocationResource.java
+++ b/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/AdmissionLocationResource.java
@@ -21,6 +21,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Location;
 import org.openmrs.LocationTag;
 import org.openmrs.api.LocationService;
@@ -95,6 +98,24 @@ public class AdmissionLocationResource extends DelegatingCrudResource<AdmissionL
 		}
 		
 		return null;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl.property("ward", new StringProperty()).property("totalBeds", new StringProperty())
+			        .property("occupiedBeds", new StringProperty());
+		}
+		if (rep instanceof FullRepresentation) {
+			modelImpl.property("ward", new StringProperty()).property("totalBeds", new StringProperty())
+			        .property("occupiedBeds", new StringProperty()).property("bedLayouts", new StringProperty());
+		}
+		if (rep instanceof NamedRepresentation) {
+			modelImpl.property("ward", new StringProperty()).property("bedLocationMappings", new StringProperty());
+		}
+		
+		return modelImpl;
 	}
 	
 	@PropertyGetter("bedLayouts")
@@ -268,6 +289,12 @@ public class AdmissionLocationResource extends DelegatingCrudResource<AdmissionL
 		description.addProperty("description");
 		description.addProperty("parentLocationUuid");
 		return description;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl().property("name", new StringProperty()).property("description", new StringProperty())
+		        .property("parentLocationUuid", new StringProperty());
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedResource.java
+++ b/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedResource.java
@@ -15,6 +15,10 @@ package org.openmrs.module.bedmanagement.rest.resource;
 
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Location;
 import org.openmrs.api.LocationService;
 import org.openmrs.api.context.Context;
@@ -72,6 +76,43 @@ public class BedResource extends DelegatingCrudResource<Bed> {
 			return description;
 		}
 		return null;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		if (rep instanceof DefaultRepresentation || rep instanceof RefRepresentation) {
+			modelImpl.property("id", new IntegerProperty()).property("uuid", new StringProperty())
+			        .property("row", new IntegerProperty()).property("column", new IntegerProperty())
+			        .property("bedNumber", new StringProperty()).property("status", new StringProperty());
+		}
+		if (rep instanceof FullRepresentation) {
+			modelImpl.property("id", new IntegerProperty()).property("uuid", new StringProperty())
+			        .property("row", new IntegerProperty()).property("column", new IntegerProperty())
+			        .property("bedNumber", new StringProperty()).property("status", new StringProperty());
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription description = new DelegatingResourceDescription();
+		description.addProperty("id");
+		description.addProperty("bedNumber");
+		description.addProperty("bedType");
+		description.addProperty("row");
+		description.addProperty("column");
+		description.addProperty("status", Representation.DEFAULT);
+		return description;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		modelImpl.property("id", new IntegerProperty()).property("uuid", new StringProperty())
+		        .property("row", new IntegerProperty()).property("column", new IntegerProperty())
+		        .property("bedNumber", new StringProperty()).property("status", new StringProperty());
+		return modelImpl;
 	}
 	
 	@PropertyGetter("row")

--- a/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedTagMapResource.java
+++ b/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedTagMapResource.java
@@ -13,6 +13,9 @@
  */
 package org.openmrs.module.bedmanagement.rest.resource;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.bedmanagement.entity.BedTagMap;
 import org.openmrs.module.bedmanagement.service.BedTagMapService;
@@ -75,4 +78,19 @@ public class BedTagMapResource extends DataDelegatingCrudResource<BedTagMap> {
 		delegatingResourceDescription.addRequiredProperty("bedTag");
 		return delegatingResourceDescription;
 	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		if (rep instanceof DefaultRepresentation || rep instanceof RefRepresentation) {
+			modelImpl.property("uuid", new StringProperty());
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl().property("bed", new StringProperty()).property("bedTag", new StringProperty());
+	}
+	
 }

--- a/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedTagResource.java
+++ b/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedTagResource.java
@@ -13,6 +13,9 @@
  */
 package org.openmrs.module.bedmanagement.rest.resource;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.bedmanagement.entity.BedType;
 import org.openmrs.module.bedmanagement.service.BedManagementService;
@@ -45,6 +48,28 @@ public class BedTagResource extends DelegatingCrudResource<BedTag> {
 		description.addProperty("name");
 		description.addProperty("uuid");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		modelImpl.property("id", new StringProperty()).property("name", new StringProperty()).property("uuid",
+		    new StringProperty());
+		
+		return modelImpl;
+	}
+	
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription description = new DelegatingResourceDescription();
+		description.addProperty("id");
+		description.addProperty("name");
+		return description;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl().property("id", new StringProperty()).property("name", new StringProperty());
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedTypeResource.java
+++ b/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedTypeResource.java
@@ -1,5 +1,8 @@
 package org.openmrs.module.bedmanagement.rest.resource;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.bedmanagement.entity.Bed;
 import org.openmrs.module.bedmanagement.entity.BedType;
@@ -37,6 +40,29 @@ public class BedTypeResource extends DelegatingCrudResource<BedType> {
 		description.addProperty("displayName");
 		description.addProperty("description");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		modelImpl.property("uuid", new StringProperty()).property("name", new StringProperty())
+		        .property("displayName", new StringProperty()).property("description", new StringProperty());
+		return modelImpl;
+	}
+	
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() {
+		DelegatingResourceDescription delegatingResourceDescription = new DelegatingResourceDescription();
+		delegatingResourceDescription.addRequiredProperty("name");
+		delegatingResourceDescription.addRequiredProperty("displayName");
+		delegatingResourceDescription.addRequiredProperty("description");
+		return delegatingResourceDescription;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl().property("name", new StringProperty()).property("displayName", new StringProperty())
+		        .property("description", new StringProperty());
 	}
 	
 	@Override

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <openMRSVersion>2.0.4</openMRSVersion>
     <openMRSRuntimeVersion>1.9.3</openMRSRuntimeVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <webservicesRestModuleVersion>2.16</webservicesRestModuleVersion>
+    <webservicesRestModuleVersion>2.21.0</webservicesRestModuleVersion>
     <openmrsAtomfeedVersion>2.5.6</openmrsAtomfeedVersion>
     <openmrsOwaVersion>1.7.0</openmrsOwaVersion>
     <atomfeed.version>1.9.4</atomfeed.version>


### PR DESCRIPTION
Fixing swagger API documentation errors by implementing the required methods.
Changed webservices rest dependency version to 2.21.0 to support the change.

Refer: https://talk.openmrs.org/t/error-in-swagger-api-documentation/33771