### PR TITLE
BED-9 | Added a change-set to add Admission Location tag

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -721,7 +721,7 @@
         <renameColumn columnDataType="int" newColumnName="bed_column_number" oldColumnName="column_number" tableName="bed_location_map" />
     </changeSet>
 
-    <changeSet id="BAH-3896_300520241229" author="mohankumar">
+    <changeSet id="BM_202405301229" author="mohankumar">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from location_tag where name='Admission Location'</sqlCheck>
         </preConditions>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -725,7 +725,7 @@
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from location_tag where name='Admission Location'</sqlCheck>
         </preConditions>
-        <comment>Adding Admission Location to loacation tag</comment>
+        <comment>Adding Admission Location to location tag</comment>
         <sql>
             INSERT INTO location_tag (name, description, creator, date_created, uuid) VALUES
             ('Admission Location',

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -720,4 +720,19 @@
         <comment>Renaming column column_number to bed_column_number in table bed_location_map because column_number is a reserved word in MySQL 8.0.2 and later</comment>
         <renameColumn columnDataType="int" newColumnName="bed_column_number" oldColumnName="column_number" tableName="bed_location_map" />
     </changeSet>
+
+    <changeSet id="BAH-3896_300520241229" author="mohankumar">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from location_tag where name='Admission Location'</sqlCheck>
+        </preConditions>
+        <comment>Adding Admission Location to loacation tag</comment>
+        <sql>
+            INSERT INTO location_tag (name, description, creator, date_created, uuid) VALUES
+            ('Admission Location',
+            'Locations with this tag will be shown for admission and bed management',
+            1,
+            now(),
+            uuid());
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds a changeset to create a location tag with name `Admission Location` as the bedmanagement activities depends on this location tag. This is added to reduce the manual configuration during a fresh implementation setup.

OpenMRS Bed Management JIRA: https://openmrs.atlassian.net/browse/BED-9
Bahmni JIRA: https://bahmni.atlassian.net/browse/BAH-3896