### PR TITLE
(fix) Typo in exception message

### DIFF
--- a/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedResource.java
+++ b/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedResource.java
@@ -267,7 +267,7 @@ public class BedResource extends DelegatingCrudResource<Bed> {
 			existingBedLocationMapping.setRow(row);
 			existingBedLocationMapping.setColumn(column);
 		} else if (existingBedLocationMapping.getBed() != null) {
-			throw new IllegalPropertyException("Already bed assign to give row & column");
+			throw new IllegalPropertyException("A bed is already assigned to the given row & column");
 		}
 		
 		existingBedLocationMapping.setBed(bed);


### PR DESCRIPTION
The exception message thrown when trying to assign a bed to column and row that already has another bed is a bit unclear. This PR just fixes that message.
<img width="1710" alt="Screenshot 2025-01-15 at 2 47 05 PM" src="https://github.com/user-attachments/assets/31c9bbf9-3275-467a-9057-81fbec10d7d7" />
