### PR TITLE
BED-19 Fix: Occupancy translation shows occupied Available and Occupied for both values

### DIFF
--- a/owa/app/components/admissionLocation/rightPanel/bedLayout/bedBlock.js
+++ b/owa/app/components/admissionLocation/rightPanel/bedLayout/bedBlock.js
@@ -71,7 +71,7 @@ export default class BedBlock extends React.PureComponent {
                 </div>
             );
         } else {
-            const statusId = this.props.bed.status === 'OCCUPIED' ? 'OCCUPIED' : 'AVAILABLE';
+            const statusId = (this.props.bed.status && this.props.bed.status.toUpperCase() === 'OCCUPIED') ? 'OCCUPIED' : 'AVAILABLE';
             const statusLabel = this.intl.formatMessage({ id: statusId });
     
             return (

--- a/owa/app/components/admissionLocation/rightPanel/bedLayout/bedBlock.js
+++ b/owa/app/components/admissionLocation/rightPanel/bedLayout/bedBlock.js
@@ -71,6 +71,9 @@ export default class BedBlock extends React.PureComponent {
                 </div>
             );
         } else {
+            const statusId = this.props.bed.status === 'OCCUPIED' ? 'OCCUPIED' : 'AVAILABLE';
+            const statusLabel = this.intl.formatMessage({ id: statusId });
+    
             return (
                 <div className="block existing-bed">
                     <div className="left-block">
@@ -78,6 +81,7 @@ export default class BedBlock extends React.PureComponent {
                             &nbsp;
                         </i>
                         <span>{this.props.bed.bedNumber}</span>
+                        <div className="bed-status-label">{statusLabel}</div>
                     </div>
                     <ul className="right-block">
                         <li>

--- a/owa/app/i18n/messages.js
+++ b/owa/app/i18n/messages.js
@@ -57,6 +57,8 @@ export default {
         ADD_NEW: 'Add New',
         BED_TAG: 'Bed Tag',
         EXISTING_BED_TYPES: 'Existing Bed Types',
-        EXISTING_BED_TAGS: 'Existing Bed Tags'
+        EXISTING_BED_TAGS: 'Existing Bed Tags',
+        AVAILABLE: 'Available',
+        OCCUPIED: 'Occupied'
     }
 };


### PR DESCRIPTION
1. I have updated  i18n/messages.js and bedBlock.js to update the status of the beds.
2. Now they clearly display occupied and available. Here are the screenshots:

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/fa220c75-83f6-485b-a046-2c903126b76a" />
