### PR TITLE
BED-34: Upgrade lodash from 4.17.4 to 4.18.0

### DIFF
--- a/owa/package.json
+++ b/owa/package.json
@@ -63,7 +63,7 @@
         "enzyme-adapter-react-16": "^1.1.0",
         "enzyme-to-json": "^3.2.2",
         "i18n-iso-639-1": "2.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.0",
         "lodash.pickby": "^4.6.0",
         "prop-types": "^15.6.0",
         "raf": "^3.4.0",

--- a/owa/yarn.lock
+++ b/owa/yarn.lock
@@ -4152,6 +4152,11 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
+lodash@4.18.0:
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.0.tgz#dfd726f07ab2e39dd763de28fcf66e395c03e440"
+  integrity sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==
+
 lodash@^4.17.14, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"


### PR DESCRIPTION
Title: BED-34: Upgrade lodash from 4.17.4 to 4.18.0

Upgraded lodash from 4.17.4 to 4.18.0 to remediate known vulnerabilities.

Files changed:
- owa/package.json
- owa/yarn.lock

https://openmrs.atlassian.net/browse/BED-34