### PR TITLE
Add ability to delete and void beds from Bed Management UI

### DIFF
--- a/api/src/main/java/org/openmrs/module/bedmanagement/dao/impl/BedManagementDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/bedmanagement/dao/impl/BedManagementDaoImpl.java
@@ -186,8 +186,10 @@ public class BedManagementDaoImpl implements BedManagementDao {
 			locations.addAll(childLocations);
 		}
 		
-		String hql = "select count(blm.bed) as totalBeds ,"
-		        + " COALESCE(sum(CASE WHEN blm.bed IS NOT NULL AND blm.bed.status = :occupied THEN 1 ELSE 0 END), 0) as occupiedBeds"
+		String hql = "select COALESCE(sum(CASE WHEN blm.bed IS NOT NULL AND blm.bed.voided = false "
+		        + "THEN 1 ELSE 0 END), 0) as totalBeds ,"
+		        + " COALESCE(sum(CASE WHEN blm.bed IS NOT NULL AND blm.bed.voided = false "
+		        + "AND blm.bed.status = :occupied THEN 1 ELSE 0 END), 0) as occupiedBeds"
 		        + " from BedLocationMapping blm where blm.location in (:locations)";
 		
 		AdmissionLocation admissionLocation = (AdmissionLocation) session.createQuery(hql)
@@ -245,7 +247,7 @@ public class BedManagementDaoImpl implements BedManagementDao {
 			bedLayout.setRowNumber(blm.getRow());
 			bedLayout.setColumnNumber(blm.getColumn());
 			bedLayout.setLocation(blm.getLocation().getName());
-			if (blm.getBed() != null) {
+			if (blm.getBed() != null && BooleanUtils.isNotTrue(blm.getBed().getVoided())) {
 				bedLayout.setBedNumber(blm.getBed().getBedNumber());
 				bedLayout.setBedId(blm.getBed().getId());
 				bedLayout.setBedUuid(blm.getBed().getUuid());

--- a/api/src/test/java/org/openmrs/module/bedmanagement/HibernateBedManagementDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/bedmanagement/HibernateBedManagementDaoTest.java
@@ -122,6 +122,24 @@ public class HibernateBedManagementDaoTest extends BaseModuleContextSensitiveTes
 	}
 	
 	@Test
+	public void shouldNotReturnVoidedBedsInAdmissionLocationLayout() throws Exception {
+		Bed bed = bedManagementDao.getBedByUuid("bb02b84b-d225-11e4-9c67-080027b662ab");
+		bed.setVoided(true);
+		bedManagementDao.saveBed(bed);
+
+		Location location = locationDao.getLocationByUuid("19e023e8-20ee-4237-ade6-9e68f897b7a9");
+		AdmissionLocation admissionLocation = bedManagementDao.getAdmissionLocationForLocation(location);
+		List<BedLayout> bedLayouts = admissionLocation.getBedLayouts();
+
+		Assert.assertEquals(5, admissionLocation.getTotalBeds());
+		Assert.assertEquals(1, admissionLocation.getOccupiedBeds());
+		Assert.assertEquals(6, bedLayouts.size());
+		Assert.assertNull(bedLayouts.get(0).getBedId());
+		Assert.assertNull(bedLayouts.get(0).getBedNumber());
+		Assert.assertNull(bedLayouts.get(0).getStatus());
+	}
+
+	@Test
 	public void shouldReturnAllAdmissionLocations() throws Exception {
 		LocationTag admissionLocationTag = locationDao
 		        .getLocationTagByName(BedManagementApiConstants.LOCATION_TAG_SUPPORTS_ADMISSION);

--- a/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedResource.java
+++ b/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedResource.java
@@ -229,8 +229,11 @@ public class BedResource extends DelegatingCrudResource<Bed> {
 			if (bed == null)
 				throw new IllegalPropertyException("Bed not exist");
 			
-			if (properties.get("bedNumber") != null)
-				bed.setBedNumber((String) properties.get("bedNumber"));
+			if (properties.get("bedNumber") != null) {
+				String bedNumber = ((String) properties.get("bedNumber")).trim();
+				validateBedNumberIsUnique(bedNumber, uuid);
+				bed.setBedNumber(bedNumber);
+			}
 			
 			if (properties.get("status") != null)
 				bed.setStatus((String) properties.get("status"));
@@ -243,12 +246,27 @@ public class BedResource extends DelegatingCrudResource<Bed> {
 			if (properties.get("bedNumber") == null || properties.get("bedType") == null || properties.get("row") == null
 			        || properties.get("column") == null || properties.get("locationUuid") == null)
 				throw new IllegalPropertyException("Required parameters: bedNumber, bedType, row, column, locationUuid");
-			bed.setBedNumber((String) properties.get("bedNumber"));
+			String bedNumber = ((String) properties.get("bedNumber")).trim();
+			validateBedNumberIsUnique(bedNumber, null);
+			bed.setBedNumber(bedNumber);
 			bed.setStatus(properties.get("status") != null ? (String) properties.get("status") : "AVAILABLE");
 			bed.setBedType(bedType);
 		}
 		
 		return bed;
+	}
+
+	private void validateBedNumberIsUnique(String bedNumber, String existingBedUuid) {
+		if (bedNumber.length() == 0) {
+			throw new IllegalPropertyException("Bed number is required");
+		}
+
+		for (Bed existingBed : getBedManagementService().getBeds(null, null)) {
+			if (existingBed.getBedNumber() != null && existingBed.getBedNumber().trim().equalsIgnoreCase(bedNumber)
+			        && (existingBedUuid == null || !existingBedUuid.equals(existingBed.getUuid()))) {
+				throw new IllegalPropertyException("A bed with bed number " + bedNumber + " already exists");
+			}
+		}
 	}
 	
 	private BedLocationMapping constructBedLocationMapping(Bed bed, String locationUuid, Integer row, Integer column) {

--- a/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedResource.java
+++ b/omod/src/main/java/org/openmrs/module/bedmanagement/rest/resource/BedResource.java
@@ -257,7 +257,7 @@ public class BedResource extends DelegatingCrudResource<Bed> {
 	}
 
 	private void validateBedNumberIsUnique(String bedNumber, String existingBedUuid) {
-		if (bedNumber.length() == 0) {
+		if (bedNumber.isEmpty()) {
 			throw new IllegalPropertyException("Bed number is required");
 		}
 

--- a/omod/src/test/java/org/openmrs/module/bedmanagement/rest/resource/BedResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/bedmanagement/rest/resource/BedResourceTest.java
@@ -175,6 +175,20 @@ public class BedResourceTest extends MainResourceControllerTest {
 		request.setContent(json.getBytes());
 		deserialize(handle(request));
 	}
+
+	@Test(expected = IllegalPropertyException.class)
+	public void shouldThrowExceptionOnDuplicateBedNumberWhenAddingBed() throws Exception {
+		MockHttpServletRequest request = request(RequestMethod.POST, getURI());
+		SimpleObject postParameters = new SimpleObject();
+		postParameters.put("bedNumber", "304-a");
+		postParameters.put("bedType", "luxury");
+		postParameters.put("row", 2);
+		postParameters.put("column", 3);
+		postParameters.put("locationUuid", "98bc9b32-9d1a-11e2-8137-0800271c1b75");
+		String json = new ObjectMapper().writeValueAsString(postParameters);
+		request.setContent(json.getBytes());
+		deserialize(handle(request));
+	}
 	
 	@Test
 	public void shouldUpdateBed() throws Exception {
@@ -193,6 +207,20 @@ public class BedResourceTest extends MainResourceControllerTest {
 		Assert.assertEquals(Integer.valueOf(2), bed.get("row"));
 		Assert.assertEquals(Integer.valueOf(3), bed.get("column"));
 		Assert.assertEquals("luxury", PropertyUtils.getProperty(bed.get("bedType"), "name"));
+	}
+
+	@Test(expected = IllegalPropertyException.class)
+	public void shouldThrowExceptionOnDuplicateBedNumberWhenUpdatingBed() throws Exception {
+		MockHttpServletRequest request = request(RequestMethod.POST, getURI() + "/" + AVAILABLE_BED_UUID);
+		SimpleObject postParameters = new SimpleObject();
+		postParameters.put("bedNumber", "304-a");
+		postParameters.put("bedType", "luxury");
+		postParameters.put("row", 2);
+		postParameters.put("column", 3);
+		postParameters.put("locationUuid", "98bc9b32-9d1a-11e2-8137-0800271c1b75");
+		String json = new ObjectMapper().writeValueAsString(postParameters);
+		request.setContent(json.getBytes());
+		deserialize(handle(request));
 	}
 	
 	@Test(expected = IllegalPropertyException.class)

--- a/owa/app/components/__tests__/admissionLocation/rightPanel/admissionLocationForm/__snapshots__/addEditBed-test.js.snap
+++ b/owa/app/components/__tests__/admissionLocation/rightPanel/admissionLocationForm/__snapshots__/addEditBed-test.js.snap
@@ -281,11 +281,18 @@ exports[`AddEditBed Should display edit bed form properly 1`] = `
             value="Save"
           />
           <input
-            className="form-btn float-left"
+            className="form-btn float-left margin-right"
             name="cancel"
             onClick={[Function]}
             type="button"
             value="Cancel"
+          />
+          <input
+            className="form-btn float-left"
+            name="delete"
+            onClick={[Function]}
+            type="button"
+            value="Delete"
           />
         </div>
       </form>

--- a/owa/app/components/__tests__/admissionLocation/rightPanel/admissionLocationForm/addEditBed-test.js
+++ b/owa/app/components/__tests__/admissionLocation/rightPanel/admissionLocationForm/addEditBed-test.js
@@ -141,6 +141,7 @@ describe('AddEditBed', () => {
         expect(editBedForm.find('#column-field').props().value).toBe(1);
         expect(editBedForm.find('#bed-number-field').props().value).toBe('100-a');
         expect(editBedForm.find('#bed-type').props().value).toBe('luxury');
+        expect(editBedForm.find("input[name='delete']").props().value).toBe('Delete');
         expect(shallowToJson(editBedForm)).toMatchSnapshot();
     });
 

--- a/owa/app/components/__tests__/admissionLocation/rightPanel/bedLayout/__snapshots__/bedBlock-test.js.snap
+++ b/owa/app/components/__tests__/admissionLocation/rightPanel/bedLayout/__snapshots__/bedBlock-test.js.snap
@@ -42,6 +42,8 @@ exports[`BedBlock Should render bed block properly 1`] = `
           aria-hidden="true"
           className="fa fa-trash"
         />
+
+        Delete
       </a>
     </li>
   </ul>

--- a/owa/app/components/admissionLocation/rightPanel/admissionLocationForm/addEditBed.js
+++ b/owa/app/components/admissionLocation/rightPanel/admissionLocationForm/addEditBed.js
@@ -27,6 +27,7 @@ export default class AddEditBed extends React.Component {
         this.onChangeBedNumberField = this.onChangeBedNumberField.bind(this);
         this.onChangeBedType = this.onChangeBedType.bind(this);
         this.onSubmitHandler = this.onSubmitHandler.bind(this);
+        this.onDeleteHandler = this.onDeleteHandler.bind(this);
         this.cancelEventHandler = this.cancelEventHandler.bind(this);
     }
 
@@ -100,7 +101,7 @@ export default class AddEditBed extends React.Component {
         event.preventDefault();
         if (this.state.rowFieldError != '' || this.state.columnFieldError != '') {
             const errorMsg = this.intl.formatMessage({id: 'FIX_ERROR_MSG'});
-            this.props.admissionLocationFunctions.notify(errorText, errorMsg);
+            this.props.admissionLocationFunctions.notify('error', errorMsg);
             return;
         }
 
@@ -144,6 +145,39 @@ export default class AddEditBed extends React.Component {
                 const error = errorResponse.response.data ? errorResponse.response.data.error : errorResponse;
                 self.props.admissionLocationFunctions.notify('error', error.message.replace(/\[|\]/g, ''));
             });
+    }
+
+    onDeleteHandler(event) {
+        event.preventDefault();
+
+        const self = this;
+        const deleteConfirmationMsg = this.intl.formatMessage(
+            {id: 'DELETE_BED_CONFIRM_MESSAGE'},
+            {bed_number: this.state.bedNumber}
+        );
+        const deleteSuccessMsg = this.intl.formatMessage({id: 'DELETE_SUCCESSFULLY'});
+        const confirmation = confirm(deleteConfirmationMsg);
+        if (confirmation) {
+            axios({
+                method: 'delete',
+                url: this.urlHelper.apiBaseUrl() + '/bed/' + this.state.bedUuid
+            })
+                .then(function() {
+                    self.props.admissionLocationFunctions.notify('success', deleteSuccessMsg);
+                    self.props.admissionLocationFunctions.setState({
+                        activePage: 'listing',
+                        pageData: {},
+                        activeUuid: self.props.activeUuid
+                    });
+                })
+                .catch(function(errorResponse) {
+                    const error = errorResponse.response.data ? errorResponse.response.data.error : errorResponse;
+                    const errorMessage = error.message.includes("BedOccupiedException")
+                        ? self.intl.formatMessage({id: 'CANNOT_DELETE_OCCUPIED_BED_ERROR'})
+                        : error.message.replace(/\[|\]/g, '');
+                    self.props.admissionLocationFunctions.notify('error', errorMessage);
+                });
+        }
     }
 
     cancelEventHandler(event) {
@@ -264,8 +298,23 @@ export default class AddEditBed extends React.Component {
                                     onClick={this.cancelEventHandler}
                                     name="cancel"
                                     value={this.intl.formatMessage({id: 'CANCEL'})}
-                                    className="form-btn float-left"
+                                    className={
+                                        this.props.operation == 'edit'
+                                            ? 'form-btn float-left margin-right'
+                                            : 'form-btn float-left'
+                                    }
                                 />
+                                {this.props.operation == 'edit' ? (
+                                    <input
+                                        type="button"
+                                        onClick={this.onDeleteHandler}
+                                        name="delete"
+                                        value={this.intl.formatMessage({id: 'DELETE'})}
+                                        className="form-btn float-left"
+                                    />
+                                ) : (
+                                    ''
+                                )}
                             </div>
                         </form>
                     </div>

--- a/owa/app/components/admissionLocation/rightPanel/bedLayout/bedBlock.js
+++ b/owa/app/components/admissionLocation/rightPanel/bedLayout/bedBlock.js
@@ -32,7 +32,7 @@ export default class BedBlock extends React.PureComponent {
         const self = this;
         const deleteConfirmationMsg = this.intl.formatMessage(
             {id: 'DELETE_BED_CONFIRM_MESSAGE'},
-            {bed_number: this.props.bedNumber}
+            {bed_number: this.props.bed.bedNumber}
         );
         const deleteSuccessMsg = this.intl.formatMessage({id: 'DELETE_SUCCESSFULLY'});
         const confirmation = confirm(deleteConfirmationMsg);
@@ -87,7 +87,8 @@ export default class BedBlock extends React.PureComponent {
                         </li>
                         <li>
                             <a href="javascript:void(0);" title="delete" onClick={this.onDeleteHandler}>
-                                <i className="fa fa-trash" aria-hidden="true" />
+                                <i className="fa fa-trash" aria-hidden="true" />{' '}
+                                {this.intl.formatMessage({id: 'DELETE'})}
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
## Summary
- Adds visible delete/void controls for beds in Bed Management UI
- Fixes bed delete confirmation to show the correct bed number
- Filters voided beds out of admission layout/count data immediately
- Prevents duplicate active bed numbers on create/update

## Testing
- Added regression coverage for voided beds in admission layout
- Added REST tests for duplicate bed number validation
- Updated UI snapshots for delete controls
