### PR TITLE
Prevent bed type from being nulled out on patient unassignment

### DIFF
--- a/api/src/main/java/org/openmrs/module/bedmanagement/dao/impl/BedManagementDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/bedmanagement/dao/impl/BedManagementDaoImpl.java
@@ -67,9 +67,9 @@ public class BedManagementDaoImpl implements BedManagementDao {
 	public Bed getBedByPatient(Patient patient) {
 		Session session = sessionFactory.getCurrentSession();
 		Bed bed = (Bed) session
-		        .createQuery("select bpa.bed.bedNumber as bedNumber,bpa.bed.id as id from BedPatientAssignment bpa "
+		        .createQuery("select bpa.bed from BedPatientAssignment bpa "
 		                + "where bpa.patient = :patient and bpa.endDatetime is null AND bpa.voided is false")
-		        .setParameter("patient", patient).setResultTransformer(Transformers.aliasToBean(Bed.class)).uniqueResult();
+		        .setParameter("patient", patient).uniqueResult();
 		return bed;
 	}
 	


### PR DESCRIPTION
When unassigning a patient from a bed, the getBedByPatient query in BedManagementDaoImpl used a partial HQL projection selecting only bedNumber and id:
This returned a Bed object with all other fields — including bedType — as null. When the service subsequently called saveBed() on this incomplete object, Hibernate persisted the null bedType back to the database, wiping the bed's type configuration on every patient discharge.
The fix is to ensure that when one is unassigned bed, bed type configuration is maintained.